### PR TITLE
[TASK] Include controller name and arguments in transaction name

### DIFF
--- a/Classes/RobertLemke/NewRelic/Package.php
+++ b/Classes/RobertLemke/NewRelic/Package.php
@@ -34,7 +34,12 @@ class Package extends BasePackage {
 			$dispatcher->connect('TYPO3\Flow\Mvc\Dispatcher', 'beforeControllerInvocation',
 				function(RequestInterface $request, ResponseInterface $response, ControllerInterface $controller) {
 					if ($request instanceof ActionRequest) {
-						newrelic_name_transaction ($request->getControllerPackageKey() . ($request->getControllerSubpackageKey() != '' ? '/' . $request->getControllerSubpackageKey() : '') . '/' . $request->getControllerActionName());
+						newrelic_name_transaction (
+							$request->getControllerPackageKey() . '/' .
+							($request->getControllerSubpackageKey() != '' ? $request->getControllerSubpackageKey() . '/' : '') .
+							$request->getControllerName() . '/' .
+							$request->getControllerActionName()
+						);
 					}
 				}
 			);


### PR DESCRIPTION
@robertlemke I think it would be helpful to have the controller name in NewRelic transaction. Currently I just got the name like `Package.Key/Action` and this change will turn it to `Package.Key/Controller/Action`
